### PR TITLE
Fixup for energy measurement (wrong type) and 2024.6 compatibility

### DIFF
--- a/custom_components/amphiro_ble/models.py
+++ b/custom_components/amphiro_ble/models.py
@@ -63,7 +63,7 @@ def _convert_advertisement(
         data = {
             (DeviceClass.COUNT,None):startCounter,
             (DeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS): temp,
-            (DeviceClass.POWER, Units.POWER_KILO_WATT): kwatts,
+            (DeviceClass.ENERGY, Units.ENERGY_KILO_WATT_HOUR): kwatts,
             (DeviceClass.TIME, UnitOfTime.SECONDS):secs,
             (DeviceClass.VOLUME_DISPENSED,Units.VOLUME_LITERS):round( pulses/2560, 2)
        

--- a/custom_components/amphiro_ble/sensor.py
+++ b/custom_components/amphiro_ble/sensor.py
@@ -1,8 +1,6 @@
 """Support for Amphiro sensors."""
 from __future__ import annotations
 
-from typing import Optional, Union
-
 from sensor_state_data import (
     DeviceKey,
     DeviceClass,
@@ -129,7 +127,7 @@ async def async_setup_entry(
 
 class AmphiroBluetoothSensorEntity(
     PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]],1]
+        PassiveBluetoothDataProcessor[float | int | None, SensorUpdate]
     ],
     SensorEntity,
 ):

--- a/custom_components/amphiro_ble/sensor.py
+++ b/custom_components/amphiro_ble/sensor.py
@@ -129,7 +129,7 @@ async def async_setup_entry(
 
 class AmphiroBluetoothSensorEntity(
     PassiveBluetoothProcessorEntity[
-        PassiveBluetoothDataProcessor[Optional[Union[float, int]]]
+        PassiveBluetoothDataProcessor[Optional[Union[float, int]],1]
     ],
     SensorEntity,
 ):

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
     "name": "Amphiro Digital Hand Shower BLE",
     "hacs": "1.6.0",
     "render_readme":true,
-    "homeassistant": "2022.12.0"
+    "homeassistant": "2024.6.0"
 }


### PR DESCRIPTION
Class for energy should not be power (it is not electricity - it is heating)
class AmphiroBluetoothSensorEntity updated in order to work with HomeAssistant build 2024.6


