### PR TITLE
keep states available all the time

### DIFF
--- a/custom_components/amphiro_ble/sensor.py
+++ b/custom_components/amphiro_ble/sensor.py
@@ -137,3 +137,20 @@ class AmphiroBluetoothSensorEntity(
     def native_value(self) -> int | float | None:
         """Return the native value."""
         return self.processor.entity_data.get(self.entity_key)
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available.
+
+        The sensor is only created when the device is seen.
+
+        Since these are sleepy devices which stop broadcasting
+        when not in use, we can't rely on the last update time
+        so once we have seen the device we always return True.
+        """
+        return True
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return True if the device is no longer broadcasting."""
+        return not self.processor.available


### PR DESCRIPTION
This PR fixes #10. It is based on code from the `oral-b` official extension, exactly in this [method](https://github.com/home-assistant/core/blob/52e6afdcca500da9fc2601bb29decdc181ab6a4d/homeassistant/components/oralb/sensor.py#L140). 

It was way simpler than I had expected, as the code for this extension and for the oral-b one were already quite similar.