### PR TITLE
Update StateClass of Liters and Seconds sensor

### DIFF
--- a/custom_components/amphiro_ble/sensor.py
+++ b/custom_components/amphiro_ble/sensor.py
@@ -49,7 +49,7 @@ SENSOR_DESCRIPTIONS: dict[
         key=f"{DeviceClass.VOLUME_DISPENSED}_{UnitOfVolume.LITERS}",
         device_class=DeviceClass.VOLUME_DISPENSED,
         native_unit_of_measurement=UnitOfVolume.LITERS,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
     (SSDSensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS): SensorEntityDescription(
         key=f"{SSDSensorDeviceClass.TEMPERATURE}_{UnitOfTemperature.CELSIUS}",
@@ -61,7 +61,7 @@ SENSOR_DESCRIPTIONS: dict[
         key=f"{DeviceClass.TIME}_{UnitOfTime.SECONDS}",
         device_class=DeviceClass.TIME,
         native_unit_of_measurement=UnitOfTime.SECONDS,
-        state_class=SensorStateClass.TOTAL,
+        state_class=SensorStateClass.TOTAL_INCREASING,
     ),
 }
 


### PR DESCRIPTION
While I haven't received mine yet and therefore can't for sure say that this is in fact an issue (hence Draft PR), while researching the topic, I did find this forum post:

https://community.home-assistant.io/t/automation-only-run-if-available-more-than-30-seconds/707187/13

>I can confirm the Hansa Activejet Bluetooth (aka Hasactivejet) is compatible and recognized, as a working well using an ESP bluetooth proxy.
>
>I did notice the water usage and time are registered as state class total by the integration, while they reset to 0 for each new cycle. So they should be state class total_increasing and I used customize.yaml to change it. That will allow to put a utility meter on it to sum total usage.

Looking at the protocol documentation [here](https://gitlab.com/baze/amphiro_oras_bluetooth_shower_hub/-/tree/main/Protocol_description?ref_type=heads#binary-data-explained), I can see that the `pulses` are `3 bytes` and `time` is `2 bytes`.
This would mean max values of `~18 hours` and about `~6500 liters`, which does sound like it's a lot less than the expected lifetime of a shower head.

Therefore, I am relatively confident that the user is right and `TOTAL_INCREASING` is the correct state class
Confident enough to open a draft PR at least 🙂 

Ref: https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes
